### PR TITLE
fix right nav on collection page

### DIFF
--- a/src/pages/specifications/collections.md
+++ b/src/pages/specifications/collections.md
@@ -5,7 +5,7 @@ page_id: "collections"
 warning: false
 updated: 2023-02-08
 contextual_links:
-  - type: subtitle
+  - type: section
     name: "Blog Posts"
   - type: link
     name: "Postman Essentials: Exploring the Collection Format"


### PR DESCRIPTION
changed title to 'section' on blog post for collections to match other pages.