### PR TITLE
docs: fix repo name in cd instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The secondary top navbar as well as the left and right navbars are custom to thi
 ```shell
 
    $ git clone https://github.com/postmanlabs/open-technologies-docs.git
-   $ cd postman-docs
+   $ cd open-technologies-docs
    $ npm run nvmrc
    $ nvm use
    $ npm install


### PR DESCRIPTION
Fixes a likely cut and paste nit in the README