### PR TITLE
reduce the size of the modal for a concept card on the GraphQL section

### DIFF
--- a/src/components/filterCards/ConceptCards.jsx
+++ b/src/components/filterCards/ConceptCards.jsx
@@ -96,8 +96,17 @@ const ModalWrapper = styled.div`
 div.modal {
   background-color: ${(props) => props.theme.colors.grey_00}!important;
   margin: auto;
-  height: 100vh;
+  height: 85vh;
   max-width: 950px;
+  border-radius: 6px;
+}
+div.modal-content {
+  margin-top: 10px;
+  height: 100%;
+  width: 100%;
+}
+div.modal-dialog {
+  margin-top: 0px;
 }
 .landing-card__content {
     text-decoration: none;


### PR DESCRIPTION
We received feedback about a lot of whitespace on the concept card. In this PR, I tried reducing the height of the concept card modal. 

![modal-size](https://user-images.githubusercontent.com/14279061/228895600-4a46f616-740b-4dbb-841b-cdc2a16dd52b.gif)
