### PR TITLE
Broken Link Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Open Technologies docs
 
-The [Postman Open Technologies Docs](https://learning.postman.com/open-technologies-docs) is the main repository behind the technical documentation that lives at https://learning.postman.com/open-technologies-docs/. The content hosted there has been created with our community for our community and is available for community contributions.
+The [Postman Open Technologies Docs](https://learning.postman.com/open-technologies-docs) is the main repository behind the technical documentation that lives at https://learning.postman.com/open-technologies/. The content hosted there has been created with our community for our community and is available for community contributions.
 
 ## Contribution guidelines
 


### PR DESCRIPTION
The main README.md page has a link to where the docs exist. The link wasn't working and led to a 404 page.

Update link to original open-technologies docs page.

# Issue
Fixes #281 




## Preview Branch(README-Link-fix)
this won't work until action is complete

https://README-Link-fix.learning.postman-beta.com/open-technologies/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Chore ("grunt task" means nothing visual to an external user)

# Description

I have added the correct link in `README.md` file which leads to the current documentation page of open-technologies docs.





# Checklist:
All need to be checked or list reason why not

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Lint tests pass locally with my changes